### PR TITLE
Add placeholder-alt-text rule and unit tests

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,6 +1,7 @@
 import type {Rule} from '../types.js'
 import {filenameAltText} from './filename-alt-text.js'
 import {vagueAltText} from './vagueAltText.js'
+import {placeholderAltText} from './placeholder-alt-text.js'
 
 // Append-only registry. Add a rule by importing it here and pushing it onto the array.
-export const allRules: Rule[] = [filenameAltText, vagueAltText]
+export const allRules: Rule[] = [filenameAltText, vagueAltText, placeholderAltText]

--- a/src/rules/placeholder-alt-text.ts
+++ b/src/rules/placeholder-alt-text.ts
@@ -1,4 +1,5 @@
 import type {Rule, RuleResult, RuleContext} from '../types.js'
+import {normalizeAltText} from './vagueAltText.js'
 
 // Known placeholder/boilerplate strings that signal the alt text was never written.
 const PLACEHOLDER_ALT_TEXT = new Set([
@@ -19,7 +20,7 @@ export const placeholderAltText: Rule = {
 
     for (const image of context.images) {
       if (image.alt === null || image.alt === '') continue
-      if (!PLACEHOLDER_ALT_TEXT.has(image.alt.trim().toLowerCase())) continue
+      if (!PLACEHOLDER_ALT_TEXT.has(normalizeAltText(image.alt))) continue
 
       results.push({
         image,

--- a/src/rules/placeholder-alt-text.ts
+++ b/src/rules/placeholder-alt-text.ts
@@ -1,0 +1,33 @@
+import type {Rule, RuleResult, RuleContext} from '../types.js'
+
+// Known placeholder/boilerplate strings that signal the alt text was never written.
+const PLACEHOLDER_ALT_TEXT = new Set([
+  'todo',
+  'tbd',
+  'placeholder',
+  'alt text',
+  'insert alt text',
+  'image alt',
+  'fixme',
+])
+
+export const placeholderAltText: Rule = {
+  id: 'placeholder-alt-text',
+  problemUrl: 'https://www.w3.org/WAI/tutorials/images/decision-tree/',
+  evaluate(context: RuleContext): RuleResult[] {
+    const results: RuleResult[] = []
+
+    for (const image of context.images) {
+      if (image.alt === null || image.alt === '') continue
+      if (!PLACEHOLDER_ALT_TEXT.has(image.alt.trim().toLowerCase())) continue
+
+      results.push({
+        image,
+        problemShort: `Image alt text is placeholder text: "${image.alt}"`,
+        solutionShort: 'Replace the placeholder with a meaningful description of the image content.',
+      })
+    }
+
+    return results
+  },
+}

--- a/src/rules/vagueAltText.ts
+++ b/src/rules/vagueAltText.ts
@@ -58,10 +58,7 @@ const VAGUE_WORDS = new Set([
   'maps',
 
   // Placeholders
-  'todo',
-  'tbd',
-  'fixme',
-  'placeholder',
+  // Note: todo, tbd, fixme, and placeholder live in placeholder-alt-text.ts.
   'sample',
   'example',
   'test',
@@ -126,7 +123,7 @@ const VAGUE_PHRASES = new Set([
  * Normalizes alt text for set check by lowercasing, collapsing
  * whitespace, and stripping trailing punctuation.
  */
-function normalizeAltText(alt: string): string {
+export function normalizeAltText(alt: string): string {
   return alt
     .trim()
     .toLowerCase()

--- a/tests/unit/placeholder-alt-text.test.ts
+++ b/tests/unit/placeholder-alt-text.test.ts
@@ -1,0 +1,54 @@
+import {describe, it, expect} from 'vitest'
+import {placeholderAltText} from '../../src/rules/placeholder-alt-text.js'
+import type {RuleContext} from '../../src/types.js'
+
+const baseImage = {
+  src: 'https://example.com/image.png',
+  role: null,
+  ariaHidden: false,
+  ariaLabel: null,
+  ariaLabelledBy: null,
+  outerHTML: '<img>',
+}
+
+function makeContext(alt: string | null): RuleContext {
+  return {url: 'https://example.com', images: [{...baseImage, alt}]}
+}
+
+const placeholders = ['todo', 'tbd', 'placeholder', 'alt text', 'insert alt text', 'image alt', 'fixme']
+
+describe('placeholder-alt-text', () => {
+  for (const placeholder of placeholders) {
+    it(`flags "${placeholder}" as placeholder alt text`, () => {
+      expect(placeholderAltText.evaluate(makeContext(placeholder))).toHaveLength(1)
+    })
+  }
+
+  it('matches case-insensitively', () => {
+    expect(placeholderAltText.evaluate(makeContext('TODO'))).toHaveLength(1)
+    expect(placeholderAltText.evaluate(makeContext('Placeholder'))).toHaveLength(1)
+    expect(placeholderAltText.evaluate(makeContext('Insert Alt Text'))).toHaveLength(1)
+  })
+
+  it('matches with surrounding whitespace', () => {
+    expect(placeholderAltText.evaluate(makeContext('  todo  '))).toHaveLength(1)
+    expect(placeholderAltText.evaluate(makeContext('\tTBD\n'))).toHaveLength(1)
+  })
+
+  it('includes a solutionShort telling the engineer to replace the placeholder', () => {
+    const [result] = placeholderAltText.evaluate(makeContext('todo'))
+    expect(result.solutionShort).toContain('Replace the placeholder')
+  })
+
+  it('does not flag a meaningful description', () => {
+    expect(placeholderAltText.evaluate(makeContext('A dog playing in the park'))).toHaveLength(0)
+  })
+
+  it('does not flag an empty string alt', () => {
+    expect(placeholderAltText.evaluate(makeContext(''))).toHaveLength(0)
+  })
+
+  it('does not flag a null alt', () => {
+    expect(placeholderAltText.evaluate(makeContext(null))).toHaveLength(0)
+  })
+})

--- a/tests/vagueAltText.test.ts
+++ b/tests/vagueAltText.test.ts
@@ -33,7 +33,7 @@ function evaluateAlts(alts: (string | null)[]) {
 
 describe('vagueAltText', () => {
   describe('flags vague single-word alt text', () => {
-    it.each(['image', 'photo', 'picture', 'icon', 'logo', 'chart', 'screenshot', 'placeholder', 'untitled', 'below'])(
+    it.each(['image', 'photo', 'picture', 'icon', 'logo', 'chart', 'screenshot', 'untitled', 'below'])(
       'flags alt="%s"',
       alt => {
         const results = evaluateAlts([alt])
@@ -97,6 +97,13 @@ describe('vagueAltText', () => {
     it('alt text that contains a vague word, but is not vague by itself', () => {
       expect(evaluateAlts(['Profile photo of Ada Lovelace'])).toHaveLength(0)
       expect(evaluateAlts(['Screenshot of the GitHub home page'])).toHaveLength(0)
+    })
+
+    it('placeholder words that now live in placeholder-alt-text', () => {
+      expect(evaluateAlts(['todo'])).toHaveLength(0)
+      expect(evaluateAlts(['tbd'])).toHaveLength(0)
+      expect(evaluateAlts(['fixme'])).toHaveLength(0)
+      expect(evaluateAlts(['placeholder'])).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
Closes #3

Adds a new deterministic rule that flags images whose alt text matches known placeholder patterns (todo, tbd, placeholder, etc.).

- Added `src/rules/placeholder-alt-text.ts` implementing the Rule interface
- Patterns defined as a constant Set for easy extension
- Registered in `src/rules/index.ts`
- Unit tests cover all patterns, case/whitespace variations, clean alt, empty, and null