### PR TITLE
Add lint and test CI workflows for PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint & Format
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    # Skip draft pull requests, but run for everything else.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,13 @@ concurrency:
 
 jobs:
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # extract.test.ts drives a real Chromium via Playwright.
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,11 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    # Skip draft pull requests, but run for everything else.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "prettier": "@github/prettier-config",
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24"
+    "node": "^22.13.0 || ^24 || ^26"
   },
   "devDependencies": {
     "@github/prettier-config": "^0.0.6",

--- a/tests/vagueAltText.test.ts
+++ b/tests/vagueAltText.test.ts
@@ -10,6 +10,7 @@ describe('vagueAltText', () => {
       alt => {
         const results = evaluateAlts([alt], vagueAltText)
         expect(results).toHaveLength(1)
+        expect(results[0]).toBeDefined()
         expect(results[0]!.image.alt).toBe(alt)
       },
     )
@@ -96,11 +97,13 @@ describe('vagueAltText', () => {
 
     it('includes the offending alt text in problemShort', () => {
       const [result] = evaluateAlts(['image'], vagueAltText)
+      expect(result).toBeDefined()
       expect(result!.problemShort).toContain('image')
     })
 
     it('includes a solutionShort', () => {
       const [result] = evaluateAlts(['image'], vagueAltText)
+      expect(result).toBeDefined()
       expect(result!.solutionShort).toBeTruthy()
     })
   })


### PR DESCRIPTION
Adds two CI workflows that run on PRs and pushes to `main`:

- **`lint.yml`** runs `npm run lint` (ESLint) and `npm run format:check` (Prettier).
- **`test.yml`** runs `npm run typecheck` (tsc) and `npm run test` (Vitest). Installs Chromium via Playwright so `extract.test.ts` can launch a real browser. Skips draft PRs.

Fixes https://github.com/github/accessibility/issues/10708. The last acceptance criteria (configure main branch protection rules) still needs to be done in repo Settings after merge.