### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     groups:
       npm-minor-and-patch:
         applies-to: version-updates
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - 'minor'
+          - 'patch'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     groups:
       github-actions:
         patterns:
-          - "*"
+          - '*'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
           - '*'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'bundler'
+    directory: '/example/site-with-errors'
+    schedule:
+      interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,21 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Closes #22

Adds a `.github/dependabot.yml` to enable Dependabot version updates for the npm and github-actions ecosystems on a weekly schedule.