### PR TITLE
Add per-rule disable configuration through json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ To override the default enabled state of one or more rules, add a `config.json` 
 - A missing or malformed `config.json` causes the plugin to run with all defaults.
 - The plugin reads the config once at startup, not per URL.
 
+### Editor autocomplete and validation
+
+A JSON Schema is published at [`schema/config.schema.json`](./schema/config.schema.json). Add a `$schema` line at the top of your `config.json` to get autocomplete, hover docs, and inline validation in editors that support JSON Schema (VS Code, JetBrains IDEs, etc.):
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
+  "rules": {
+    "repeated-alt-text": false
+  }
+}
+```
+
+The `$schema` line is optional and is ignored by the plugin at runtime. It only powers editor-time validation.
+
 ---
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The scanner uses these fields to file or update a GitHub issue.
 
 ## Configuration
 
-Every rule is enabled by default. To disable specific rules, add a `config.json` file next to the plugin's `index.ts` in your scanner repository:
+To override the default enabled state of one or more rules, add a `config.json` file next to the plugin's `index.ts` in your scanner repository:
 
 ```
 .github/scanner-plugins/alt-text-scan/
@@ -155,14 +155,20 @@ Every rule is enabled by default. To disable specific rules, add a `config.json`
 
 ```json
 {
-  "disabledRules": ["repeated-alt-text", "placeholder-alt-text"]
+  "rules": {
+    "repeated-alt-text": false,
+    "placeholder-alt-text": false
+  }
 }
 ```
 
-- `disabledRules` accepts any rule ID listed in the [Rules](#rules) table above.
-- Unknown rule IDs are logged as warnings and ignored (typo guard).
-- A missing or malformed `config.json` causes the plugin to run with all rules enabled — the config is strictly additive: it can only ever turn rules off, never on.
+- Each key under `rules` is a rule ID from the [Rules](#rules) table above; the value is `true` (run the rule) or `false` (skip it).
+- Rules you don't list keep their default behavior. Today every rule defaults to enabled.
+- Unknown rule IDs and non-boolean values are logged as warnings and ignored (typo guard).
+- A missing or malformed `config.json` causes the plugin to run with all defaults.
 - The plugin reads the config once at startup, not per URL.
+
+The top-level shape (`{"rules": {...}}`) leaves room for future non-rule settings without breaking existing configs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ To override the default enabled state of one or more rules, add a `config.json` 
 - A missing or malformed `config.json` causes the plugin to run with all defaults.
 - The plugin reads the config once at startup, not per URL.
 
-### Editor autocomplete and validation
-
 A JSON Schema is published at [`schema/config.schema.json`](./schema/config.schema.json). Add a `$schema` line at the top of your `config.json` to get autocomplete, hover docs, and inline validation in editors that support JSON Schema (VS Code, JetBrains IDEs, etc.):
 
 ```json
@@ -181,7 +179,7 @@ A JSON Schema is published at [`schema/config.schema.json`](./schema/config.sche
 }
 ```
 
-The `$schema` line is optional and is ignored by the plugin at runtime. It only powers editor-time validation.
+The `$schema` line is optional and is ignored by the plugin at runtime. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ A JSON Schema is published at [`schema/config.schema.json`](./schema/config.sche
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
+  "$schema":   "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
   "rules": {
     "repeated-alt-text": false
   }
 }
 ```
 
-The `$schema` line is optional and is ignored by the plugin at runtime. 
+The `$schema` line is optional and is ignored by the plugin at runtime.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A JSON Schema is published at [`schema/config.schema.json`](./schema/config.sche
 
 ```json
 {
-  "$schema":   "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
+  "$schema": "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
   "rules": {
     "repeated-alt-text": false
   }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The plugin inherits the a11y scanner's general FAQ — see the link above for qu
 
 ## Background
 
-This plugin exists to catch low-quality `alt` text that axe-core's built-in [`image-alt`](https://dequeuniversity.com/rules/axe/4.10/image-alt) rule cannot — patterns like vague single-word `alt`, raw filenames, runs of duplicate `alt`, and never-filled-in placeholders. Scope is intentionally narrow: deterministic, heuristic checks on `<img>` elements only. Non-`<img>` `role="img"` elements, decorative `alt=""`, and hidden subtrees are filtered out before any rule runs.
+This plugin exists to catch low-quality `alt` text that axe-core's built-in [`image-alt`](https://dequeuniversity.com/rules/axe/4.10/image-alt) rule cannot — patterns like vague single-word `alt`, raw filenames, runs of duplicate `alt`, and never-filled-in placeholders. The scope is intentionally narrow: deterministic, heuristic checks on `<img>` elements only. Non-`<img>` `role="img"` elements, decorative `alt=""`, and hidden subtrees are filtered out before any rule runs.
 
-The rule registry is append-only and the project is under active development alongside the scanner's public preview. Roadmap and open work live in this repo's [Issues](https://github.com/github/accessibility-scanner-alt-text-plugin/issues). See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to contribute, including local setup, expected checks, and PR conventions.
+The project is under active development alongside the scanner's public preview. Roadmap and open work live in this repo's [Issues](https://github.com/github/accessibility-scanner-alt-text-plugin/issues). See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to contribute, including local setup, expected checks, and PR conventions.
 
 ---
 
@@ -140,6 +140,29 @@ When a rule fires, the plugin emits a finding with the following shape (matching
 - `solutionLong` — optional longer explanation when one-sentence isn't enough
 
 The scanner uses these fields to file or update a GitHub issue.
+
+---
+
+## Configuration
+
+Every rule is enabled by default. To disable specific rules, add a `config.json` file next to the plugin's `index.ts` in your scanner repository:
+
+```
+.github/scanner-plugins/alt-text-scan/
+├── index.ts
+└── config.json   ← optional
+```
+
+```json
+{
+  "disabledRules": ["repeated-alt-text", "placeholder-alt-text"]
+}
+```
+
+- `disabledRules` accepts any rule ID listed in the [Rules](#rules) table above.
+- Unknown rule IDs are logged as warnings and ignored (typo guard).
+- A missing or malformed `config.json` causes the plugin to run with all rules enabled — the config is strictly additive: it can only ever turn rules off, never on.
+- The plugin reads the config once at startup, not per URL.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,6 @@ To override the default enabled state of one or more rules, add a `config.json` 
 - A missing or malformed `config.json` causes the plugin to run with all defaults.
 - The plugin reads the config once at startup, not per URL.
 
-The top-level shape (`{"rules": {...}}`) leaves room for future non-rule settings without breaking existing configs.
-
 ---
 
 ## Development

--- a/index.ts
+++ b/index.ts
@@ -8,18 +8,15 @@ import type {PluginArgs} from './src/types.js'
 export const name = 'alt-text-scan'
 
 // Config lives in the consumer's repo at `.github/scanner-plugins/<name>/config.json`.
-// `process.cwd()` is the consumer repo root when invoked by the scanner action.
 const configPath = join(process.cwd(), '.github', 'scanner-plugins', name, 'config.json')
 const knownRuleIds = new Set(allRules.map(r => r.id))
-
-// Read the config once per scanner process; the same config applies to every URL.
 const configPromise = loadConfig(configPath, knownRuleIds)
 
 export default async function altTextScan({page, addFinding}: PluginArgs): Promise<void> {
   const url = page.url()
 
-  const {disabledRules} = await configPromise
-  const enabledRules = allRules.filter(rule => !disabledRules.has(rule.id))
+  const {ruleOverrides} = await configPromise
+  const enabledRules = allRules.filter(rule => ruleOverrides.get(rule.id) ?? rule.defaultEnabled ?? true)
 
   // Extract images from the page.
   let images

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,25 @@
+import {join} from 'node:path'
 import {extractImages} from './src/extract.js'
 import {allRules} from './src/rules/index.js'
 import {emitFindings} from './src/findings.js'
+import {loadConfig} from './src/config.js'
 import type {PluginArgs} from './src/types.js'
 
 export const name = 'alt-text-scan'
 
+// Config lives in the consumer's repo at `.github/scanner-plugins/<name>/config.json`.
+// `process.cwd()` is the consumer repo root when invoked by the scanner action.
+const configPath = join(process.cwd(), '.github', 'scanner-plugins', name, 'config.json')
+const knownRuleIds = new Set(allRules.map(r => r.id))
+
+// Read the config once per scanner process; the same config applies to every URL.
+const configPromise = loadConfig(configPath, knownRuleIds)
+
 export default async function altTextScan({page, addFinding}: PluginArgs): Promise<void> {
   const url = page.url()
+
+  const {disabledRules} = await configPromise
+  const enabledRules = allRules.filter(rule => !disabledRules.has(rule.id))
 
   // Extract images from the page.
   let images
@@ -22,7 +35,7 @@ export default async function altTextScan({page, addFinding}: PluginArgs): Promi
   const ctx = {url, images}
 
   // Enforce checks on each image against each rule.
-  for (const rule of allRules) {
+  for (const rule of enabledRules) {
     let results
     try {
       results = rule.evaluate(ctx)

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/github/accessibility-scanner-alt-text-plugin/main/schema/config.schema.json",
+  "title": "alt-text-scan plugin configuration",
+  "description": "Configuration for the alt-text-scan plugin used by the GitHub Accessibility Scanner. See https://github.com/github/accessibility-scanner-alt-text-plugin#configuration for details.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional reference to this schema for editor-time validation. Ignored at scanner runtime."
+    },
+    "rules": {
+      "type": "object",
+      "description": "Per-rule enable/disable overrides. Rules not listed keep their default behavior (today, every rule defaults to enabled).",
+      "additionalProperties": false,
+      "properties": {
+        "missing-alt-text": {
+          "type": "boolean",
+          "description": "Flags <img> elements where the alt attribute is absent or whitespace-only. alt=\"\" is treated as intentional decorative use and is not flagged."
+        },
+        "vague-alt-text": {
+          "type": "boolean",
+          "description": "Flags alt text that is a generic single word (image, photo, icon, logo, screenshot, etc.) or short filler phrase (an image of, a photo of)."
+        },
+        "filename-alt-text": {
+          "type": "boolean",
+          "description": "Flags alt text that ends in a common image file extension (.png, .jpg, .jpeg, .gif, .svg, .webp, .bmp, .ico)."
+        },
+        "placeholder-alt-text": {
+          "type": "boolean",
+          "description": "Flags alt text matching a known boilerplate string (todo, tbd, fixme, placeholder, alt text, insert alt text, image alt)."
+        },
+        "repeated-alt-text": {
+          "type": "boolean",
+          "description": "Flags two or more adjacent images in the rendered page that share the same normalized alt text."
+        }
+      }
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,10 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
   let raw: string
   try {
     raw = await readFile(configPath, 'utf8')
-  } catch {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.error(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
+    }
     return EMPTY_CONFIG
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,46 @@
+import {readFile} from 'node:fs/promises'
+
+export type PluginConfig = {
+  disabledRules: ReadonlySet<string>
+}
+
+const EMPTY_CONFIG: PluginConfig = {disabledRules: new Set()}
+
+export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<string>): Promise<PluginConfig> {
+  let raw: string
+  try {
+    raw = await readFile(configPath, 'utf8')
+  } catch {
+    return EMPTY_CONFIG
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    console.error(`[alt-text-scan] failed to parse ${configPath}; running with all rules enabled:`, err)
+    return EMPTY_CONFIG
+  }
+
+  return {disabledRules: collectDisabledRules(parsed, knownRuleIds)}
+}
+
+function collectDisabledRules(parsed: unknown, knownRuleIds: ReadonlySet<string>): Set<string> {
+  const result = new Set<string>()
+  if (!parsed || typeof parsed !== 'object') return result
+
+  const list = (parsed as {disabledRules?: unknown}).disabledRules
+  if (!Array.isArray(list)) return result
+
+  for (const id of list) {
+    if (typeof id !== 'string') continue
+    if (!knownRuleIds.has(id)) {
+      console.warn(
+        `[alt-text-scan] unknown rule id "${id}" in config; ignoring. Known ids: ${[...knownRuleIds].join(', ')}`,
+      )
+      continue
+    }
+    result.add(id)
+  }
+  return result
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,10 +12,10 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
     raw = await readFile(configPath, 'utf8')
   } catch (err) {
     if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-      return EMPTY_CONFIG
+      return emptyConfig()
     }
     console.log(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
-    return EMPTY_CONFIG
+    return emptyConfig()
   }
 
   let parsed: unknown
@@ -23,7 +23,7 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
     parsed = JSON.parse(raw)
   } catch (err) {
     console.error(`[alt-text-scan] failed to parse ${configPath}; running with default rule settings:`, err)
-    return EMPTY_CONFIG
+    return emptyConfig()
   }
 
   return {ruleOverrides: collectRuleOverrides(parsed, knownRuleIds)}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,9 +11,10 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
   try {
     raw = await readFile(configPath, 'utf8')
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
-      console.error(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      return EMPTY_CONFIG
     }
+    console.log(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
     return EMPTY_CONFIG
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
     if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
       return emptyConfig()
     }
-    console.log(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
+    console.warn(`[alt-text-scan] failed to read ${configPath}; running with default rule settings:`, err)
     return emptyConfig()
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
 import {readFile} from 'node:fs/promises'
 
 export type PluginConfig = {
-  disabledRules: ReadonlySet<string>
+  ruleOverrides: ReadonlyMap<string, boolean>
 }
 
-const EMPTY_CONFIG: PluginConfig = {disabledRules: new Set()}
+const EMPTY_CONFIG: PluginConfig = {ruleOverrides: new Map()}
 
 export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<string>): Promise<PluginConfig> {
   let raw: string
@@ -18,29 +18,32 @@ export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<s
   try {
     parsed = JSON.parse(raw)
   } catch (err) {
-    console.error(`[alt-text-scan] failed to parse ${configPath}; running with all rules enabled:`, err)
+    console.error(`[alt-text-scan] failed to parse ${configPath}; running with default rule settings:`, err)
     return EMPTY_CONFIG
   }
 
-  return {disabledRules: collectDisabledRules(parsed, knownRuleIds)}
+  return {ruleOverrides: collectRuleOverrides(parsed, knownRuleIds)}
 }
 
-function collectDisabledRules(parsed: unknown, knownRuleIds: ReadonlySet<string>): Set<string> {
-  const result = new Set<string>()
+function collectRuleOverrides(parsed: unknown, knownRuleIds: ReadonlySet<string>): Map<string, boolean> {
+  const result = new Map<string, boolean>()
   if (!parsed || typeof parsed !== 'object') return result
 
-  const list = (parsed as {disabledRules?: unknown}).disabledRules
-  if (!Array.isArray(list)) return result
+  const rules = (parsed as {rules?: unknown}).rules
+  if (!rules || typeof rules !== 'object' || Array.isArray(rules)) return result
 
-  for (const id of list) {
-    if (typeof id !== 'string') continue
+  for (const [id, value] of Object.entries(rules as Record<string, unknown>)) {
     if (!knownRuleIds.has(id)) {
       console.warn(
         `[alt-text-scan] unknown rule id "${id}" in config; ignoring. Known ids: ${[...knownRuleIds].join(', ')}`,
       )
       continue
     }
-    result.add(id)
+    if (typeof value !== 'boolean') {
+      console.warn(`[alt-text-scan] non-boolean value for rule "${id}" in config (got ${typeof value}); ignoring.`)
+      continue
+    }
+    result.set(id, value)
   }
   return result
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export type PluginConfig = {
   ruleOverrides: ReadonlyMap<string, boolean>
 }
 
-const EMPTY_CONFIG: PluginConfig = {ruleOverrides: new Map()}
+const emptyConfig = (): PluginConfig => ({ruleOverrides: new Map()})
 
 export async function loadConfig(configPath: string, knownRuleIds: ReadonlySet<string>): Promise<PluginConfig> {
   let raw: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,5 +60,8 @@ export type RuleResult = {
 export type Rule = {
   id: string
   problemUrl: string
+  // Whether the rule runs when the consumer hasn't explicitly configured it.
+  // Optional; treated as `true` when absent.
+  defaultEnabled?: boolean
   evaluate(ctx: RuleContext): RuleResult[]
 }

--- a/tests/example-site.test.ts
+++ b/tests/example-site.test.ts
@@ -1,11 +1,12 @@
 import {readFileSync} from 'node:fs'
 import {fileURLToPath} from 'node:url'
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest'
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 import {chromium, type Browser, type Page} from 'playwright'
 import altTextScan from '../index.js'
 import type {Finding} from '../src/types.js'
 
 const errorsPagePath = fileURLToPath(new URL('../example/site-with-errors/alt-text-errors.html', import.meta.url))
+const fixtureWithDisabledRule = fileURLToPath(new URL('./fixtures/with-disabled-rule', import.meta.url))
 
 // Strips the Jekyll/Liquid front matter so the raw <img> markup can be loaded
 // directly into Playwright without running a Jekyll build.
@@ -68,5 +69,36 @@ describe('example site-with-errors', () => {
     })
 
     expect(findings).toHaveLength(0)
+  })
+
+  it('skips a rule disabled in the consumer config.json', async () => {
+    const originalCwd = process.cwd()
+    process.chdir(fixtureWithDisabledRule)
+    vi.resetModules()
+    try {
+      const {default: altTextScanWithConfig} = await import('../index.js')
+
+      const body = loadErrorsPageBody()
+      await page.setContent(`<!doctype html><html><body>${body}</body></html>`)
+
+      const findings: Finding[] = []
+      await altTextScanWithConfig({
+        page,
+        addFinding: async finding => {
+          findings.push(finding)
+        },
+      })
+
+      const ruleIds = new Set(findings.map(f => f.ruleId))
+      // The disabled rule must not fire.
+      expect(ruleIds.has('missing-alt-text')).toBe(false)
+      const {allRules} = await import('../src/rules/index.js')
+      for (const rule of allRules) {
+        if (rule.id === 'missing-alt-text') continue
+        expect(ruleIds).toContain(rule.id)
+      }
+    } finally {
+      process.chdir(originalCwd)
+    }
   })
 })

--- a/tests/fixtures/with-disabled-rule/.github/scanner-plugins/alt-text-scan/config.json
+++ b/tests/fixtures/with-disabled-rule/.github/scanner-plugins/alt-text-scan/config.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "missing-alt-text": false
+  }
+}

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -3,14 +3,9 @@ import {mkdtemp, writeFile, rm} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {loadConfig} from '../../src/config.js'
+import {allRules} from '../../src/rules/index.js'
 
-const KNOWN = new Set([
-  'missing-alt-text',
-  'vague-alt-text',
-  'filename-alt-text',
-  'placeholder-alt-text',
-  'repeated-alt-text',
-])
+const KNOWN = new Set(allRules.map(r => r.id))
 
 describe('loadConfig', () => {
   let dir: string
@@ -28,6 +23,15 @@ describe('loadConfig', () => {
   it('returns empty overrides when the file is missing', async () => {
     const cfg = await loadConfig(configPath, KNOWN)
     expect(cfg.ruleOverrides.size).toBe(0)
+  })
+
+  it('logs an error and returns empty when read fails for a non-ENOENT reason', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Pointing at a directory makes readFile fail with EISDIR rather than ENOENT.
+    const cfg = await loadConfig(dir, KNOWN)
+    expect(cfg.ruleOverrides.size).toBe(0)
+    expect(err).toHaveBeenCalled()
+    err.mockRestore()
   })
 
   it('returns empty overrides when the file is an empty object', async () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -25,35 +25,54 @@ describe('loadConfig', () => {
     await rm(dir, {recursive: true, force: true})
   })
 
-  it('returns empty disabledRules when the file is missing', async () => {
+  it('returns empty overrides when the file is missing', async () => {
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 
-  it('returns empty disabledRules when the file is an empty object', async () => {
+  it('returns empty overrides when the file is an empty object', async () => {
     await writeFile(configPath, '{}')
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 
-  it('returns empty disabledRules when disabledRules is an empty array', async () => {
-    await writeFile(configPath, JSON.stringify({disabledRules: []}))
+  it('returns empty overrides when rules is an empty object', async () => {
+    await writeFile(configPath, JSON.stringify({rules: {}}))
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 
-  it('returns the disabled rule ids when valid', async () => {
-    await writeFile(configPath, JSON.stringify({disabledRules: ['repeated-alt-text', 'placeholder-alt-text']}))
+  it('returns the overrides when valid', async () => {
+    await writeFile(
+      configPath,
+      JSON.stringify({rules: {'repeated-alt-text': false, 'placeholder-alt-text': false, 'vague-alt-text': true}}),
+    )
     const cfg = await loadConfig(configPath, KNOWN)
-    expect([...cfg.disabledRules].sort()).toEqual(['placeholder-alt-text', 'repeated-alt-text'])
+    expect(cfg.ruleOverrides.get('repeated-alt-text')).toBe(false)
+    expect(cfg.ruleOverrides.get('placeholder-alt-text')).toBe(false)
+    expect(cfg.ruleOverrides.get('vague-alt-text')).toBe(true)
+    expect(cfg.ruleOverrides.size).toBe(3)
   })
 
   it('warns and ignores unknown rule ids', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    await writeFile(configPath, JSON.stringify({disabledRules: ['repeated-alt-text', 'no-such-rule']}))
+    await writeFile(configPath, JSON.stringify({rules: {'repeated-alt-text': false, 'no-such-rule': false}}))
     const cfg = await loadConfig(configPath, KNOWN)
-    expect([...cfg.disabledRules]).toEqual(['repeated-alt-text'])
+    expect([...cfg.ruleOverrides.keys()]).toEqual(['repeated-alt-text'])
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('no-such-rule'))
+    warn.mockRestore()
+  })
+
+  it('warns and ignores non-boolean values', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await writeFile(
+      configPath,
+      JSON.stringify({rules: {'vague-alt-text': false, 'repeated-alt-text': 'off', 'placeholder-alt-text': 1}}),
+    )
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect([...cfg.ruleOverrides.keys()]).toEqual(['vague-alt-text'])
+    expect(cfg.ruleOverrides.get('vague-alt-text')).toBe(false)
+    expect(warn).toHaveBeenCalledTimes(2)
     warn.mockRestore()
   })
 
@@ -61,26 +80,32 @@ describe('loadConfig', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     await writeFile(configPath, '{ this is not json')
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
     expect(err).toHaveBeenCalled()
     err.mockRestore()
   })
 
-  it('ignores non-string entries in disabledRules', async () => {
-    await writeFile(configPath, JSON.stringify({disabledRules: ['vague-alt-text', 123, null, {}]}))
+  it('ignores rules when it is not a plain object', async () => {
+    await writeFile(configPath, JSON.stringify({rules: ['repeated-alt-text']}))
     const cfg = await loadConfig(configPath, KNOWN)
-    expect([...cfg.disabledRules]).toEqual(['vague-alt-text'])
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 
-  it('ignores disabledRules when it is not an array', async () => {
-    await writeFile(configPath, JSON.stringify({disabledRules: 'repeated-alt-text'}))
+  it('ignores rules when it is a string', async () => {
+    await writeFile(configPath, JSON.stringify({rules: 'repeated-alt-text'}))
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 
   it('ignores top-level non-object JSON', async () => {
     await writeFile(configPath, JSON.stringify(['repeated-alt-text']))
     const cfg = await loadConfig(configPath, KNOWN)
-    expect(cfg.disabledRules.size).toBe(0)
+    expect(cfg.ruleOverrides.size).toBe(0)
+  })
+
+  it('ignores top-level keys other than rules', async () => {
+    await writeFile(configPath, JSON.stringify({somethingElse: {'vague-alt-text': false}}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.ruleOverrides.size).toBe(0)
   })
 })

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,86 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
+import {mkdtemp, writeFile, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {loadConfig} from '../../src/config.js'
+
+const KNOWN = new Set([
+  'missing-alt-text',
+  'vague-alt-text',
+  'filename-alt-text',
+  'placeholder-alt-text',
+  'repeated-alt-text',
+])
+
+describe('loadConfig', () => {
+  let dir: string
+  let configPath: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'alt-text-scan-cfg-'))
+    configPath = join(dir, 'config.json')
+  })
+
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true})
+  })
+
+  it('returns empty disabledRules when the file is missing', async () => {
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+  })
+
+  it('returns empty disabledRules when the file is an empty object', async () => {
+    await writeFile(configPath, '{}')
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+  })
+
+  it('returns empty disabledRules when disabledRules is an empty array', async () => {
+    await writeFile(configPath, JSON.stringify({disabledRules: []}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+  })
+
+  it('returns the disabled rule ids when valid', async () => {
+    await writeFile(configPath, JSON.stringify({disabledRules: ['repeated-alt-text', 'placeholder-alt-text']}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect([...cfg.disabledRules].sort()).toEqual(['placeholder-alt-text', 'repeated-alt-text'])
+  })
+
+  it('warns and ignores unknown rule ids', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await writeFile(configPath, JSON.stringify({disabledRules: ['repeated-alt-text', 'no-such-rule']}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect([...cfg.disabledRules]).toEqual(['repeated-alt-text'])
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no-such-rule'))
+    warn.mockRestore()
+  })
+
+  it('falls back to empty when JSON is malformed and logs an error', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await writeFile(configPath, '{ this is not json')
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+    expect(err).toHaveBeenCalled()
+    err.mockRestore()
+  })
+
+  it('ignores non-string entries in disabledRules', async () => {
+    await writeFile(configPath, JSON.stringify({disabledRules: ['vague-alt-text', 123, null, {}]}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect([...cfg.disabledRules]).toEqual(['vague-alt-text'])
+  })
+
+  it('ignores disabledRules when it is not an array', async () => {
+    await writeFile(configPath, JSON.stringify({disabledRules: 'repeated-alt-text'}))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+  })
+
+  it('ignores top-level non-object JSON', async () => {
+    await writeFile(configPath, JSON.stringify(['repeated-alt-text']))
+    const cfg = await loadConfig(configPath, KNOWN)
+    expect(cfg.disabledRules.size).toBe(0)
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -25,13 +25,13 @@ describe('loadConfig', () => {
     expect(cfg.ruleOverrides.size).toBe(0)
   })
 
-  it('logs an error and returns empty when read fails for a non-ENOENT reason', async () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+  it('logs and returns empty when read fails for a non-ENOENT reason', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     // Pointing at a directory makes readFile fail with EISDIR rather than ENOENT.
     const cfg = await loadConfig(dir, KNOWN)
     expect(cfg.ruleOverrides.size).toBe(0)
-    expect(err).toHaveBeenCalled()
-    err.mockRestore()
+    expect(log).toHaveBeenCalled()
+    log.mockRestore()
   })
 
   it('returns empty overrides when the file is an empty object', async () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -26,12 +26,12 @@ describe('loadConfig', () => {
   })
 
   it('logs and returns empty when read fails for a non-ENOENT reason', async () => {
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     // Pointing at a directory makes readFile fail with EISDIR rather than ENOENT.
     const cfg = await loadConfig(dir, KNOWN)
     expect(cfg.ruleOverrides.size).toBe(0)
-    expect(log).toHaveBeenCalled()
-    log.mockRestore()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 
   it('returns empty overrides when the file is an empty object', async () => {


### PR DESCRIPTION
Closes #20.

Adds opt-out configuration for individual rules. Consumers create `.github/scanner-plugins/alt-text-scan/config.json` in their scanner repo:

```json
{
  "rules": {
    "repeated-alt-text": false,
    "placeholder-alt-text": false
  }
}