### PR TITLE
Add node to tsconfig types for TypeScript 6.0 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM"],
+    "types": ["node"],
     "strict": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Closes #30

TypeScript 6.0 no longer automatically includes `@types/node` globals, causing CI failures on PR #29. This adds `"types": ["node"]` to `tsconfig.json` so that `node:fs` and `node:url` are resolved correctly.