### PR TITLE
Add workflow to test alt-text plugin on static GitHub sites

### DIFF
--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -1,0 +1,39 @@
+name: Scan static GitHub sites (alt-text plugin)
+
+# Manually triggered workflow that runs the accessibility scanner with the
+# alt-text-scan plugin enabled against public GitHub static sites. Any issues
+# opened by the scanner are routed to a test repository for validation.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: octodex
+            urls: https://octodex.github.com/
+            repository: github/accessibility-scanner-testing
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Stage alt-text plugin
+        run: |
+          mkdir -p .github/scanner-plugins/alt-text-scan
+          cp -r index.ts src .github/scanner-plugins/alt-text-scan/
+
+      - name: Run accessibility scanner
+        uses: github/accessibility-scanner@1b9502344c5fa3ecc95e88c5d97da9e498a73ef4 # v3.2.0
+        with:
+          urls: ${{ matrix.urls }}
+          cache_key: cached_findings-${{ matrix.id }}-${{ github.ref_name }}.json
+          repository: ${{ matrix.repository }}
+          token: ${{ secrets.GH_TOKEN }}
+          skip_copilot_assignment: true
+          scans: '["axe", "alt-text-scan"]'

--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -21,7 +21,7 @@ jobs:
             repository: github/accessibility-scanner-testing
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@v6
 
       - name: Stage alt-text plugin
         run: |
@@ -32,7 +32,7 @@ jobs:
         uses: github/accessibility-scanner@1b9502344c5fa3ecc95e88c5d97da9e498a73ef4 # v3.2.0
         with:
           urls: ${{ matrix.urls }}
-          cache_key: cached_findings-${{ matrix.id }}-${{ github.ref_name }}.json
+          cache_key: cached_findings-${{ matrix.id }}-${{ replace(github.ref_name, '/', '-') }}.json
           repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_TOKEN }}
           skip_copilot_assignment: true


### PR DESCRIPTION
Closes #32

Adds a `workflow_dispatch` workflow that runs the accessibility scanner with the `alt-text-scan` plugin enabled against [Octodex](https://octodex.github.com/), modeled on the [accessibility-scorecard scanner workflow](https://github.com/github/accessibility-scorecard/blob/main/.github/workflows/accessibility-scanner.yml). Issues opened by the scanner are routed to the test repo `github/accessibility-scanner-testing`, and no teams are pinged. Requires a `GH_TOKEN` secret with issue-write access to the test repo before it can run.

Reference: github/accessibility#10737