### PR TITLE
Fix invalid cache_key expression in scan-static-sites workflow

### DIFF
--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -32,7 +32,7 @@ jobs:
         uses: github/accessibility-scanner@1b9502344c5fa3ecc95e88c5d97da9e498a73ef4 # v3.2.0
         with:
           urls: ${{ matrix.urls }}
-          cache_key: cached_findings-${{ matrix.id }}-${{ replace(github.ref_name, '/', '-') }}.json
+          cache_key: cached_findings-${{ matrix.id }}-${{ github.ref_name }}.json
           repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_TOKEN }}
           skip_copilot_assignment: true


### PR DESCRIPTION
Fixes the invalid workflow file from #33. GitHub Actions expressions have no `replace`/`replaceAll` function, so `cache_key` failed to parse. Reverts to plain `${{ github.ref_name }}` (we only dispatch from `main`, so no `/` sanitization is needed).