### PR TITLE
Add remaining sites to the workflow

### DIFF
--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -19,6 +19,15 @@ jobs:
           - id: octodex
             urls: https://octodex.github.com/
             repository: github/accessibility-scanner-testing
+          - id: universe
+            urls: https://githubuniverse.com/
+            repository: github/accessibility-scanner-testing
+          - id: shop
+            urls: https://thegithubshop.com/
+            repository: github/accessibility-scanner-testing
+          - id: blog
+            urls: https://github.blog/
+            repository: github/accessibility-scanner-testing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Adds GitHub Universe, Shop, and Blog to the `scan-static-sites` matrix, alongside Octodex. Completes the sites in github/accessibility#10737.

- All issues route to the `github/accessibility-scanner-testing` test repo — no teams pinged.