### PR TITLE
Redact query/fragment from URLs sent to model and logs

### DIFF
--- a/src/rules/alt-text-quality.ts
+++ b/src/rules/alt-text-quality.ts
@@ -5,6 +5,7 @@ import {createJudge} from '../judges/index.js'
 import type {JudgeAltText, JudgeVerdict} from '../judges/index.js'
 import type {Rule, RuleContext, RuleResult, ImageRecord} from '../types.js'
 import {loadImageAsDataUrl} from '../utils/load-image-data-url.js'
+import {redactUrl} from '../utils/redact-url.js'
 
 // Lazily build the judge so missing tokens surface only when the rule actually
 // runs
@@ -47,7 +48,7 @@ function buildContextString(image: ImageRecord, pageUrl: string): string {
   if (image.pageTitle) parts.push(`Page title: ${JSON.stringify(image.pageTitle)}`)
   if (image.sectionHeading) parts.push(`Nearest heading above the image: ${JSON.stringify(image.sectionHeading)}`)
   parts.push(`Image HTML: ${sanitizeImageHtml(image.outerHTML)}`)
-  if (image.inLink) parts.push(`The image is inside a link with href="${image.inLink.href}".`)
+  if (image.inLink) parts.push(`The image is inside a link with href="${redactUrl(image.inLink.href)}".`)
   if (image.inButton) parts.push('The image is inside a button (or role="button" element).')
   if (image.figcaption) parts.push(`Adjacent figcaption: ${JSON.stringify(image.figcaption)}`)
   if (image.nearbyText) parts.push(`Surrounding body text: ${JSON.stringify(image.nearbyText)}`)
@@ -102,7 +103,7 @@ export const altTextQuality: Rule = {
       try {
         dataUrl = await loadImageAsDataUrl(resolved)
       } catch (err) {
-        console.error(`[alt-text-quality] failed to load ${resolved}:`, err)
+        console.error(`[alt-text-quality] failed to load ${redactUrl(resolved)}:`, err)
         continue
       }
 
@@ -116,7 +117,7 @@ export const altTextQuality: Rule = {
           naturalHeight: image.naturalHeight,
         })
       } catch (err) {
-        console.error(`[alt-text-quality] judge failed for ${resolved}:`, err)
+        console.error(`[alt-text-quality] judge failed for ${redactUrl(resolved)}:`, err)
         continue
       }
 

--- a/src/rules/alt-text-quality.ts
+++ b/src/rules/alt-text-quality.ts
@@ -103,8 +103,7 @@ export const altTextQuality: Rule = {
       try {
         dataUrl = await loadImageAsDataUrl(resolved)
       } catch (err) {
-        const msg = (err instanceof Error ? err.message : String(err)).replace(/([?#])[^\s]*/g, '$1…')
-        console.error(`[alt-text-quality] failed to load ${redactUrl(resolved)}: ${redactUrl(msg)}`)
+        console.error(`[alt-text-quality] failed to load ${redactUrl(resolved)}: ${redactUrl(String(err))}`)
         continue
       }
 
@@ -118,8 +117,7 @@ export const altTextQuality: Rule = {
           naturalHeight: image.naturalHeight,
         })
       } catch (err) {
-        const msg = (err instanceof Error ? err.message : String(err)).replace(/([?#])[^\s]*/g, '$1…')
-        console.error(`[alt-text-quality] judge failed for ${redactUrl(resolved)}: ${redactUrl(msg)}`)
+        console.error(`[alt-text-quality] judge failed for ${redactUrl(resolved)}: ${redactUrl(String(err))}`)
         continue
       }
 

--- a/src/rules/alt-text-quality.ts
+++ b/src/rules/alt-text-quality.ts
@@ -103,7 +103,8 @@ export const altTextQuality: Rule = {
       try {
         dataUrl = await loadImageAsDataUrl(resolved)
       } catch (err) {
-        console.error(`[alt-text-quality] failed to load ${redactUrl(resolved)}:`, err)
+        const msg = (err instanceof Error ? err.message : String(err)).replace(/([?#])[^\s]*/g, '$1…')
+        console.error(`[alt-text-quality] failed to load ${redactUrl(resolved)}: ${redactUrl(msg)}`)
         continue
       }
 
@@ -117,7 +118,8 @@ export const altTextQuality: Rule = {
           naturalHeight: image.naturalHeight,
         })
       } catch (err) {
-        console.error(`[alt-text-quality] judge failed for ${redactUrl(resolved)}:`, err)
+        const msg = (err instanceof Error ? err.message : String(err)).replace(/([?#])[^\s]*/g, '$1…')
+        console.error(`[alt-text-quality] judge failed for ${redactUrl(resolved)}: ${redactUrl(msg)}`)
         continue
       }
 

--- a/src/utils/redact-url.ts
+++ b/src/utils/redact-url.ts
@@ -1,0 +1,15 @@
+// Strips the query string and fragment from a URL so potentially sensitive
+// values (signed-CDN tokens, session ids, user identifiers) are not forwarded
+// to the model context or written to CI logs. Origin + path are preserved for
+// debuggability. Inputs that don't parse as URLs are returned with anything
+// after '?' or '#' dropped as a fallback.
+export function redactUrl(url: string): string {
+  try {
+    const u = new URL(url)
+    u.search = ''
+    u.hash = ''
+    return u.toString()
+  } catch {
+    return url.split(/[?#]/)[0] ?? url
+  }
+}

--- a/tests/unit/alt-text-quality.test.ts
+++ b/tests/unit/alt-text-quality.test.ts
@@ -125,4 +125,20 @@ describe('alt-text-quality', () => {
     expect(context).toContain('src="(omitted)"')
     expect(context).toContain('srcset="(omitted)"')
   })
+
+  it('redacts query/fragment from the link href in the judge context', async () => {
+    const fake = new FakeJudge(() => verdict())
+    __setJudge(fake)
+    await run([
+      makeImage({
+        src: DATA_URL,
+        alt: 'a dog',
+        inLink: {href: 'https://example.com/page?sig=secret123#frag'},
+      }),
+    ])
+    const context = fake.calls[0]!.context
+    expect(context).not.toContain('sig=secret123')
+    expect(context).not.toContain('#frag')
+    expect(context).toContain('https://example.com/page')
+  })
 })

--- a/tests/unit/redact-url.test.ts
+++ b/tests/unit/redact-url.test.ts
@@ -1,0 +1,17 @@
+import {describe, it, expect} from 'vitest'
+import {redactUrl} from '../../src/utils/redact-url.js'
+
+describe('redactUrl', () => {
+  it('strips the query string', () => {
+    expect(redactUrl('https://cdn.example.com/img.png?sig=secret123')).toBe('https://cdn.example.com/img.png')
+  })
+  it('strips the fragment', () => {
+    expect(redactUrl('https://example.com/page#section')).toBe('https://example.com/page')
+  })
+  it('leaves a clean URL unchanged', () => {
+    expect(redactUrl('https://example.com/img.png')).toBe('https://example.com/img.png')
+  })
+  it('falls back gracefully on non-URL input', () => {
+    expect(redactUrl('not a url?x=1')).toBe('not a url')
+  })
+})


### PR DESCRIPTION
Follow-up to #38. 
Builds on the bot's href redaction catch and extends it: pulls the href plus the two console.error image-URL logs in evaluate() (which leak the same querystring data into CI logs) into one reusable redactUrl() helper. Keeps the original link/button wording, the rewording in the bot's inline suggestion is a separate concern.