### PR TITLE
Add repository field to fix provenance validation on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Alt-text validation plugin for github/accessibility-scanner",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/github/accessibility-scanner-alt-text-plugin.git"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Add `repository` field to fix npm provenance validation

The `v1.0.0` publish failed with `E422 Unprocessable Entity` because
`package.json` had no `repository` field. Publishing with `--provenance`
requires `repository.url` to match the repo the build ran in
(`https://github.com/github/accessibility-scanner-alt-text-plugin`), and an
empty value fails Sigstore provenance validation:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@github%2faccessibility-scanner-alt-text-plugin - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/github/accessibility-scanner-alt-text-plugin" from provenance
```

This adds the `repository` field so provenance validation passes.

Once merged, I'll recreate the `v1.0.0` release so the tag includes this fix
and the package publishes to npm.

Part of github/accessibility#10755 