### PR TITLE
Migrate scanner workflow to v3.4.0 NPM plugin loading

### DIFF
--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -50,6 +50,14 @@ jobs:
               https://github.blog/ai-and-ml/
             repository: github/accessibility-scanner-testing
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Stage alt-text plugin
+        run: |
+          mkdir -p .github/scanner-plugins/alt-text-scan
+          cp -r index.ts src .github/scanner-plugins/alt-text-scan/
+
       - name: Run accessibility scanner
         uses: github/accessibility-scanner@da2381e50d31f6e21c4fb6fad14e75f26e682ae1 # v3.4.0
         with:
@@ -58,5 +66,4 @@ jobs:
           repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_TOKEN }}
           skip_copilot_assignment: true
-          scans: |
-            ["axe", {"name": "alt-text-scan", "package": "@github/accessibility-scanner-alt-text-plugin", "version": "1.1.0"}]
+          scans: '["axe", "alt-text-scan"]'

--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -50,20 +50,13 @@ jobs:
               https://github.blog/ai-and-ml/
             repository: github/accessibility-scanner-testing
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Stage alt-text plugin
-        run: |
-          mkdir -p .github/scanner-plugins/alt-text-scan
-          cp -r index.ts src .github/scanner-plugins/alt-text-scan/
-
       - name: Run accessibility scanner
-        uses: github/accessibility-scanner@84a8f6de0b0f7df7ac2083386222388d0e74eeb9 # v3.3.0
+        uses: github/accessibility-scanner@da2381e50d31f6e21c4fb6fad14e75f26e682ae1 # v3.4.0
         with:
           urls: ${{ matrix.urls }}
           cache_key: cached_findings-${{ matrix.id }}-${{ github.ref_name }}.json
           repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_TOKEN }}
           skip_copilot_assignment: true
-          scans: '["axe", "alt-text-scan"]'
+          scans: |
+            ["axe", {"name": "alt-text-scan", "package": "@github/accessibility-scanner-alt-text-plugin", "version": "1.1.0"}]

--- a/.github/workflows/scan-static-sites.yml
+++ b/.github/workflows/scan-static-sites.yml
@@ -50,14 +50,6 @@ jobs:
               https://github.blog/ai-and-ml/
             repository: github/accessibility-scanner-testing
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Stage alt-text plugin
-        run: |
-          mkdir -p .github/scanner-plugins/alt-text-scan
-          cp -r index.ts src .github/scanner-plugins/alt-text-scan/
-
       - name: Run accessibility scanner
         uses: github/accessibility-scanner@da2381e50d31f6e21c4fb6fad14e75f26e682ae1 # v3.4.0
         with:
@@ -66,4 +58,5 @@ jobs:
           repository: ${{ matrix.repository }}
           token: ${{ secrets.GH_TOKEN }}
           skip_copilot_assignment: true
-          scans: '["axe", "alt-text-scan"]'
+          scans: |
+            ["axe", {"name": "alt-text-scan", "package": "@github/accessibility-scanner-alt-text-plugin", "version": "1.1.0"}]


### PR DESCRIPTION
Bumps the scanner action to v3.4.0 and loads the alt-text plugin from npm (`@github/accessibility-scanner-alt-text-plugin@1.1.0`) via the new object form of the `scans` input.

Since v3.4.0 can resolve plugins as packages, we no longer need to check out this repo and copy `index.ts`/`src` into `.github/scanner-plugins/` before the scan, so those two steps are gone. Everything else (urls, cache keys, target repo, token, `skip_copilot_assignment`) is unchanged.

I didn't dispatch the workflow itself, it scans live sites and writes issues/cache, but I ran v3.4.0's plugin loader against the published package locally and confirmed it kept `axe` and picked up the `alt-text-scan` export.

Revert to go back to v3.3.0 with local plugin staging; nothing to migrate.